### PR TITLE
feat: AI 분석 파이프라인 — Gemini API (#10)

### DIFF
--- a/__tests__/analyze-news.test.ts
+++ b/__tests__/analyze-news.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  analyzeRecentNews,
+  generateDailyBriefing,
+} from "../src/usecases/analyze-news";
+import type {
+  AnalyzerPort,
+  AnalysisRepositoryPort,
+} from "../src/domain/analysis/ports";
+import type { NewsRepositoryPort } from "../src/domain/news/ports";
+import type { Article } from "../src/domain/news/entities";
+import type { AiAnalysis } from "../src/domain/analysis/entities";
+
+function createMockArticle(id: string): Article {
+  return {
+    id,
+    sourceId: `src-${id}`,
+    source: "test",
+    url: `https://example.com/${id}`,
+    title: { en: "Test article title", ko: "", ja: "" },
+    summary: { en: "Test article summary", ko: "", ja: "" },
+    category: "diplomacy",
+    region: "europe",
+    severity: "medium",
+    imageUrl: null,
+    publishedAt: new Date("2026-03-13"),
+    collectedAt: new Date("2026-03-13"),
+  };
+}
+
+function createMockNewsRepo(articles: Article[] = []): NewsRepositoryPort {
+  return {
+    save: vi.fn().mockResolvedValue(undefined),
+    findLatest: vi.fn().mockResolvedValue(articles),
+    findByRegion: vi.fn().mockResolvedValue([]),
+    findByCategory: vi.fn().mockResolvedValue([]),
+    existsBySourceId: vi.fn().mockResolvedValue(false),
+    filterExistingSourceIds: vi.fn().mockResolvedValue(new Set()),
+  };
+}
+
+function createMockAnalyzer(): AnalyzerPort {
+  return {
+    summarize: vi.fn().mockResolvedValue({
+      text: "Summary of the article",
+      model: "test-model",
+    }),
+    analyzeSentiment: vi.fn().mockResolvedValue({
+      score: -0.5,
+      label: "negative",
+      reasoning: "Conflict escalation",
+    }),
+    generateBriefing: vi.fn().mockResolvedValue({
+      date: new Date(),
+      content: "## Daily Briefing\n\nKey developments...",
+      model: "test-flash",
+    }),
+    clusterIssues: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function createMockAnalysisRepo(
+  existingAnalyses: AiAnalysis[] = [],
+): AnalysisRepositoryPort {
+  return {
+    save: vi.fn().mockResolvedValue(undefined),
+    findByTarget: vi.fn().mockResolvedValue(existingAnalyses),
+    findLatestBriefing: vi.fn().mockResolvedValue(null),
+  };
+}
+
+describe("analyzeRecentNews", () => {
+  it("should summarize and analyze sentiment for articles", async () => {
+    const articles = [createMockArticle("1"), createMockArticle("2")];
+    const newsRepo = createMockNewsRepo(articles);
+    const analyzer = createMockAnalyzer();
+    const analysisRepo = createMockAnalysisRepo();
+
+    const result = await analyzeRecentNews(
+      newsRepo,
+      analyzer,
+      analysisRepo,
+    );
+
+    expect(result.summarized).toBe(2);
+    expect(result.sentimentAnalyzed).toBe(2);
+    // 2 articles × 2 types (summary + sentiment) = 4 saves
+    expect(analysisRepo.save).toHaveBeenCalledTimes(4);
+  });
+
+  it("should skip already analyzed articles", async () => {
+    const articles = [createMockArticle("1")];
+    const newsRepo = createMockNewsRepo(articles);
+    const analyzer = createMockAnalyzer();
+    const existingAnalysis: AiAnalysis = {
+      id: "existing",
+      targetType: "article",
+      targetId: "1",
+      type: "summary",
+      result: { en: "Already summarized", ko: "", ja: "" },
+      sentiment: null,
+      sentimentLabel: null,
+      model: "test",
+      createdAt: new Date(),
+    };
+    const analysisRepo = createMockAnalysisRepo([existingAnalysis]);
+
+    const result = await analyzeRecentNews(
+      newsRepo,
+      analyzer,
+      analysisRepo,
+    );
+
+    expect(result.summarized).toBe(0); // skipped
+    expect(result.sentimentAnalyzed).toBe(1); // only sentiment
+    expect(analysisRepo.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle empty article list", async () => {
+    const newsRepo = createMockNewsRepo([]);
+    const analyzer = createMockAnalyzer();
+    const analysisRepo = createMockAnalysisRepo();
+
+    const result = await analyzeRecentNews(
+      newsRepo,
+      analyzer,
+      analysisRepo,
+    );
+
+    expect(result.summarized).toBe(0);
+    expect(result.sentimentAnalyzed).toBe(0);
+  });
+
+  it("should continue on individual analysis failure", async () => {
+    const articles = [createMockArticle("1")];
+    const newsRepo = createMockNewsRepo(articles);
+    const analyzer = createMockAnalyzer();
+    (analyzer.summarize as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("API error"),
+    );
+    const analysisRepo = createMockAnalysisRepo();
+
+    const result = await analyzeRecentNews(
+      newsRepo,
+      analyzer,
+      analysisRepo,
+    );
+
+    expect(result.summarized).toBe(0); // failed
+    expect(result.sentimentAnalyzed).toBe(1); // still works
+  });
+});
+
+describe("generateDailyBriefing", () => {
+  it("should generate and save a briefing", async () => {
+    const articles = [createMockArticle("1"), createMockArticle("2")];
+    const newsRepo = createMockNewsRepo(articles);
+    const analyzer = createMockAnalyzer();
+    const analysisRepo = createMockAnalysisRepo();
+
+    const briefing = await generateDailyBriefing(
+      newsRepo,
+      analyzer,
+      analysisRepo,
+    );
+
+    expect(briefing.targetType).toBe("daily_briefing");
+    expect(briefing.type).toBe("briefing");
+    expect(briefing.result.en).toContain("Daily Briefing");
+    expect(analysisRepo.save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/gemini-analyzer.test.ts
+++ b/__tests__/gemini-analyzer.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSentimentResponse,
+  parseClustersResponse,
+} from "../src/adapters/ai/gemini-analyzer";
+
+describe("parseSentimentResponse", () => {
+  it("should parse valid sentiment JSON", () => {
+    const response = JSON.stringify({
+      score: -0.7,
+      label: "negative",
+      reasoning: "Military escalation indicates negative outlook",
+    });
+
+    const result = parseSentimentResponse(response);
+    expect(result.score).toBe(-0.7);
+    expect(result.label).toBe("negative");
+    expect(result.reasoning).toBe(
+      "Military escalation indicates negative outlook",
+    );
+  });
+
+  it("should extract JSON from surrounding text", () => {
+    const response = `Here is the analysis:
+{"score": 0.3, "label": "positive", "reasoning": "Trade agreement progress"}
+Done.`;
+
+    const result = parseSentimentResponse(response);
+    expect(result.score).toBe(0.3);
+    expect(result.label).toBe("positive");
+  });
+
+  it("should throw on missing JSON", () => {
+    expect(() => parseSentimentResponse("No JSON here")).toThrow(
+      "No JSON object found",
+    );
+  });
+
+  it("should throw on invalid score range", () => {
+    const response = JSON.stringify({
+      score: 2.0,
+      label: "positive",
+      reasoning: "test",
+    });
+    expect(() => parseSentimentResponse(response)).toThrow(
+      "Invalid sentiment score",
+    );
+  });
+
+  it("should throw on invalid label", () => {
+    const response = JSON.stringify({
+      score: 0.5,
+      label: "super_positive",
+      reasoning: "test",
+    });
+    expect(() => parseSentimentResponse(response)).toThrow(
+      "Invalid sentiment label",
+    );
+  });
+
+  it("should accept all valid labels", () => {
+    const labels = [
+      "very_negative",
+      "negative",
+      "neutral",
+      "positive",
+      "very_positive",
+    ];
+    for (const label of labels) {
+      const response = JSON.stringify({ score: 0, label, reasoning: "test" });
+      const result = parseSentimentResponse(response);
+      expect(result.label).toBe(label);
+    }
+  });
+});
+
+describe("parseClustersResponse", () => {
+  it("should parse valid cluster JSON array", () => {
+    const response = JSON.stringify([
+      {
+        label: "Ukraine Conflict",
+        articleIds: ["a1", "a2"],
+        summary: "Ongoing military operations",
+      },
+      {
+        label: "Iran Nuclear",
+        articleIds: ["a3"],
+        summary: "Nuclear negotiations update",
+      },
+    ]);
+
+    const result = parseClustersResponse(response);
+    expect(result).toHaveLength(2);
+    expect(result[0].label).toBe("Ukraine Conflict");
+    expect(result[0].articleIds).toEqual(["a1", "a2"]);
+    expect(result[1].summary).toBe("Nuclear negotiations update");
+  });
+
+  it("should extract JSON array from surrounding text", () => {
+    const response = `Here are the clusters:
+[{"label": "Test", "articleIds": ["a1"], "summary": "test"}]
+End.`;
+
+    const result = parseClustersResponse(response);
+    expect(result).toHaveLength(1);
+  });
+
+  it("should throw on missing JSON array", () => {
+    expect(() => parseClustersResponse("No JSON here")).toThrow(
+      "No JSON array found",
+    );
+  });
+
+  it("should handle missing fields gracefully", () => {
+    const response = JSON.stringify([{ label: "Test" }]);
+    const result = parseClustersResponse(response);
+    expect(result[0].articleIds).toEqual([]);
+    expect(result[0].summary).toBe("");
+  });
+});

--- a/src/adapters/ai/gemini-analyzer.ts
+++ b/src/adapters/ai/gemini-analyzer.ts
@@ -1,0 +1,174 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import type { AnalyzerPort } from "../../domain/analysis/ports";
+import type {
+  Summary,
+  SentimentResult,
+  BriefingReport,
+  IssueCluster,
+} from "../../domain/analysis/entities";
+import type { Article } from "../../domain/news/entities";
+import type { SentimentLabel } from "../../shared/types";
+
+const VALID_LABELS = new Set<SentimentLabel>([
+  "very_negative",
+  "negative",
+  "neutral",
+  "positive",
+  "very_positive",
+]);
+
+function parseSentimentResponse(responseText: string): SentimentResult {
+  const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error("No JSON object found in sentiment response");
+  }
+
+  const parsed = JSON.parse(jsonMatch[0]);
+  const score = Number(parsed.score);
+  if (isNaN(score) || score < -1 || score > 1) {
+    throw new Error(`Invalid sentiment score: ${parsed.score}`);
+  }
+
+  const label = String(parsed.label) as SentimentLabel;
+  if (!VALID_LABELS.has(label)) {
+    throw new Error(`Invalid sentiment label: ${parsed.label}`);
+  }
+
+  return {
+    score,
+    label,
+    reasoning: String(parsed.reasoning ?? ""),
+  };
+}
+
+function parseClustersResponse(responseText: string): IssueCluster[] {
+  const jsonMatch = responseText.match(/\[[\s\S]*\]/);
+  if (!jsonMatch) {
+    throw new Error("No JSON array found in cluster response");
+  }
+
+  const parsed = JSON.parse(jsonMatch[0]);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Expected JSON array for clusters");
+  }
+
+  return parsed.map((c: Record<string, unknown>) => ({
+    label: String(c.label ?? ""),
+    articleIds: Array.isArray(c.articleIds)
+      ? c.articleIds.map(String)
+      : [],
+    summary: String(c.summary ?? ""),
+  }));
+}
+
+export class GeminiAnalyzer implements AnalyzerPort {
+  private genAI: GoogleGenerativeAI;
+  private liteModel: string;
+  private flashModel: string;
+
+  constructor(apiKey?: string, liteModel?: string, flashModel?: string) {
+    const key = apiKey ?? process.env.GEMINI_API_KEY ?? "";
+    if (!key) {
+      throw new Error("GEMINI_API_KEY is required");
+    }
+    this.genAI = new GoogleGenerativeAI(key);
+    this.liteModel = liteModel ?? "gemini-2.5-flash-lite";
+    this.flashModel = flashModel ?? "gemini-2.5-flash";
+  }
+
+  async summarize(text: string): Promise<Summary> {
+    const model = this.genAI.getGenerativeModel({ model: this.liteModel });
+    const prompt = `Summarize the following geopolitical news in 2-3 concise sentences. Focus on key facts, actors, and implications.
+
+Text: ${text}`;
+
+    const result = await model.generateContent(prompt);
+    return {
+      text: result.response.text().trim(),
+      model: this.liteModel,
+    };
+  }
+
+  async analyzeSentiment(text: string): Promise<SentimentResult> {
+    const model = this.genAI.getGenerativeModel({ model: this.liteModel });
+    const prompt = `Analyze the sentiment of this geopolitical news article.
+Return a JSON object:
+{
+  "score": <float -1.0 to 1.0>,
+  "label": "very_negative|negative|neutral|positive|very_positive",
+  "reasoning": "<1 sentence explanation>"
+}
+
+Text: ${text}`;
+
+    const result = await model.generateContent(prompt);
+    return parseSentimentResponse(result.response.text());
+  }
+
+  async generateBriefing(articles: Article[]): Promise<BriefingReport> {
+    const model = this.genAI.getGenerativeModel({ model: this.flashModel });
+    const articleList = articles
+      .map(
+        (a, i) =>
+          `${i + 1}. [${a.category}/${a.region}] ${a.title.en}${a.summary?.en ? ` — ${a.summary.en}` : ""}`,
+      )
+      .join("\n");
+
+    const prompt = `You are a geopolitical analyst. Generate a daily briefing report based on the following news articles.
+
+Structure:
+## Daily Geopolitical Briefing
+
+### Key Summary
+(3-5 bullet points of the most critical developments)
+
+### Regional Analysis
+(Group by region, highlight tensions and trends)
+
+### Risk Assessment
+(Identify emerging risks and escalation patterns)
+
+### Outlook
+(Brief forward-looking analysis)
+
+Articles:
+${articleList}`;
+
+    const result = await model.generateContent(prompt);
+    return {
+      date: new Date(),
+      content: result.response.text().trim(),
+      model: this.flashModel,
+    };
+  }
+
+  async clusterIssues(articles: Article[]): Promise<IssueCluster[]> {
+    const model = this.genAI.getGenerativeModel({ model: this.flashModel });
+    const articleList = articles
+      .map(
+        (a) =>
+          `- id:"${a.id}" title:"${a.title.en}" category:${a.category} region:${a.region}`,
+      )
+      .join("\n");
+
+    const prompt = `Group the following news articles into thematic clusters. Each cluster should represent a distinct geopolitical issue or event.
+
+Return a JSON array:
+[
+  {
+    "label": "<short cluster label>",
+    "articleIds": ["<article id>", ...],
+    "summary": "<1-2 sentence summary of this issue>"
+  }
+]
+
+Articles:
+${articleList}`;
+
+    const result = await model.generateContent(prompt);
+    return parseClustersResponse(result.response.text());
+  }
+}
+
+// Exported for testing
+export { parseSentimentResponse, parseClustersResponse };

--- a/src/adapters/repositories/analysis-repository.ts
+++ b/src/adapters/repositories/analysis-repository.ts
@@ -1,0 +1,62 @@
+import type { AnalysisRepositoryPort } from "../../domain/analysis/ports";
+import type { AiAnalysis } from "../../domain/analysis/entities";
+import type { AnalysisTargetType, Language, SentimentLabel } from "../../shared/types";
+import type { PrismaClient } from "../../generated/prisma/client";
+
+function toAiAnalysis(row: Record<string, unknown>): AiAnalysis {
+  return {
+    id: row.id as string,
+    targetType: row.targetType as AnalysisTargetType,
+    targetId: (row.targetId as string) ?? null,
+    type: row.type as AiAnalysis["type"],
+    result: {
+      en: row.resultEn as string,
+      ko: row.resultKo as string,
+      ja: row.resultJa as string,
+    },
+    sentiment: (row.sentiment as number) ?? null,
+    sentimentLabel: null,
+    model: row.model as string,
+    createdAt: new Date(row.createdAt as string | Date),
+  };
+}
+
+export class AnalysisRepository implements AnalysisRepositoryPort {
+  constructor(private prisma: PrismaClient) {}
+
+  async save(analysis: AiAnalysis): Promise<void> {
+    await this.prisma.aiAnalysis.create({
+      data: {
+        id: analysis.id,
+        targetType: analysis.targetType,
+        targetId: analysis.targetId,
+        type: analysis.type,
+        resultEn: analysis.result.en,
+        resultKo: analysis.result.ko,
+        resultJa: analysis.result.ja,
+        sentiment: analysis.sentiment,
+        model: analysis.model,
+      },
+    });
+  }
+
+  async findByTarget(
+    targetType: AnalysisTargetType,
+    targetId: string,
+  ): Promise<AiAnalysis[]> {
+    const rows = await this.prisma.aiAnalysis.findMany({
+      where: { targetType, targetId },
+      orderBy: { createdAt: "desc" },
+    });
+    return rows.map((r) => toAiAnalysis(r as unknown as Record<string, unknown>));
+  }
+
+  async findLatestBriefing(lang: Language): Promise<AiAnalysis | null> {
+    const row = await this.prisma.aiAnalysis.findFirst({
+      where: { type: "briefing" },
+      orderBy: { createdAt: "desc" },
+    });
+    if (!row) return null;
+    return toAiAnalysis(row as unknown as Record<string, unknown>);
+  }
+}

--- a/src/usecases/analyze-news.ts
+++ b/src/usecases/analyze-news.ts
@@ -1,0 +1,103 @@
+import type { AnalyzerPort, AnalysisRepositoryPort } from "../domain/analysis/ports";
+import type { NewsRepositoryPort } from "../domain/news/ports";
+import type { AiAnalysis } from "../domain/analysis/entities";
+import { randomUUID } from "crypto";
+
+export interface AnalyzeNewsResult {
+  summarized: number;
+  sentimentAnalyzed: number;
+}
+
+export async function analyzeRecentNews(
+  newsRepository: NewsRepositoryPort,
+  analyzer: AnalyzerPort,
+  analysisRepository: AnalysisRepositoryPort,
+  limit = 20,
+): Promise<AnalyzeNewsResult> {
+  const articles = await newsRepository.findLatest(limit, "en");
+  let summarized = 0;
+  let sentimentAnalyzed = 0;
+
+  for (const article of articles) {
+    const text = `${article.title.en}. ${article.summary?.en ?? ""}`;
+
+    // Check if already analyzed
+    const existing = await analysisRepository.findByTarget("article", article.id);
+    const hasSummary = existing.some((a) => a.type === "summary");
+    const hasSentiment = existing.some((a) => a.type === "sentiment");
+
+    if (!hasSummary) {
+      try {
+        const summary = await analyzer.summarize(text);
+        const analysis: AiAnalysis = {
+          id: randomUUID(),
+          targetType: "article",
+          targetId: article.id,
+          type: "summary",
+          result: { en: summary.text, ko: "", ja: "" },
+          sentiment: null,
+          sentimentLabel: null,
+          model: summary.model,
+          createdAt: new Date(),
+        };
+        await analysisRepository.save(analysis);
+        summarized++;
+      } catch (error) {
+        console.warn(
+          `Summary failed for article ${article.id}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+    }
+
+    if (!hasSentiment) {
+      try {
+        const sentiment = await analyzer.analyzeSentiment(text);
+        const analysis: AiAnalysis = {
+          id: randomUUID(),
+          targetType: "article",
+          targetId: article.id,
+          type: "sentiment",
+          result: { en: sentiment.reasoning, ko: "", ja: "" },
+          sentiment: sentiment.score,
+          sentimentLabel: sentiment.label,
+          model: "gemini-2.5-flash-lite",
+          createdAt: new Date(),
+        };
+        await analysisRepository.save(analysis);
+        sentimentAnalyzed++;
+      } catch (error) {
+        console.warn(
+          `Sentiment analysis failed for article ${article.id}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+    }
+  }
+
+  return { summarized, sentimentAnalyzed };
+}
+
+export async function generateDailyBriefing(
+  newsRepository: NewsRepositoryPort,
+  analyzer: AnalyzerPort,
+  analysisRepository: AnalysisRepositoryPort,
+): Promise<AiAnalysis> {
+  const articles = await newsRepository.findLatest(50, "en");
+  const briefing = await analyzer.generateBriefing(articles);
+
+  const analysis: AiAnalysis = {
+    id: randomUUID(),
+    targetType: "daily_briefing",
+    targetId: null,
+    type: "briefing",
+    result: { en: briefing.content, ko: "", ja: "" },
+    sentiment: null,
+    sentimentLabel: null,
+    model: briefing.model,
+    createdAt: new Date(),
+  };
+
+  await analysisRepository.save(analysis);
+  return analysis;
+}


### PR DESCRIPTION
## Summary
- **GeminiAnalyzer** 어댑터: `AnalyzerPort` 구현 (요약/감성분석/브리핑/클러스터링)
- **AnalysisRepository**: AiAnalysis Prisma CRUD (타겟별 조회, 최신 브리핑 조회)
- **analyzeRecentNews**: 미분석 Article 자동 요약 + 감성분석 (기존 분석 스킵, 개별 실패 무시)
- **generateDailyBriefing**: 최근 50건 뉴스 기반 구조화된 일간 브리핑 생성
- 모델 전략: Flash-Lite(요약/감성) + Flash(브리핑/클러스터링)

## Test plan
- [x] 감성 분석 JSON 파싱 (정상, 주변 텍스트, score 범위, label 검증)
- [x] 클러스터 JSON 파싱 (정상, 누락 필드 처리)
- [x] 뉴스 분석 유스케이스: 요약+감성 동시 수행
- [x] 기존 분석 존재 시 스킵
- [x] 빈 기사 목록 처리
- [x] 개별 분석 실패 시 계속 진행
- [x] 일간 브리핑 생성 및 저장
- [x] 전체 테스트 통과 (112/112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)