### PR TITLE
feat: 배치 스케줄러 + API Routes 통합 (#11, #12)

### DIFF
--- a/__tests__/scheduler.test.ts
+++ b/__tests__/scheduler.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import cron from "node-cron";
+
+describe("scheduler configuration", () => {
+  it("should validate cron expressions", () => {
+    // News: every 15 minutes
+    expect(cron.validate("*/15 * * * *")).toBe(true);
+    // Market: every 15 minutes
+    expect(cron.validate("*/15 * * * *")).toBe(true);
+    // Geopolitics: every 30 minutes
+    expect(cron.validate("*/30 * * * *")).toBe(true);
+    // Daily briefing: 06:00 KST (21:00 UTC)
+    expect(cron.validate("0 21 * * *")).toBe(true);
+    // Translation: every hour
+    expect(cron.validate("0 * * * *")).toBe(true);
+  });
+
+  it("should reject invalid cron expressions", () => {
+    expect(cron.validate("invalid")).toBe(false);
+    expect(cron.validate("")).toBe(false);
+  });
+});

--- a/app/api/analysis/briefing/route.ts
+++ b/app/api/analysis/briefing/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { prisma } from "../../../../src/infrastructure/prisma";
+import { AnalysisRepository } from "../../../../src/adapters/repositories/analysis-repository";
+import type { Language } from "../../../../src/shared/types";
+
+const repo = new AnalysisRepository(prisma);
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const lang = (searchParams.get("lang") ?? "ko") as Language;
+
+  try {
+    const briefing = await repo.findLatestBriefing(lang);
+
+    if (!briefing) {
+      return NextResponse.json(
+        { error: "No briefing available", code: 404 },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ data: briefing });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch briefing", code: 500 },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/geo-events/route.ts
+++ b/app/api/geo-events/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { prisma } from "../../../src/infrastructure/prisma";
+import { GeoRepository } from "../../../src/adapters/repositories/geo-repository";
+import type { GeoEventType, Language, Severity } from "../../../src/shared/types";
+
+const repo = new GeoRepository(prisma);
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const lang = (searchParams.get("lang") ?? "ko") as Language;
+  const limit = Math.min(Number(searchParams.get("limit") ?? "50"), 100);
+  const severity = searchParams.get("severity") as Severity | null;
+  const eventType = searchParams.get("eventType") as GeoEventType | null;
+
+  try {
+    let events;
+    if (severity) {
+      events = await repo.findBySeverity(severity, lang, limit);
+    } else if (eventType) {
+      events = await repo.findByEventType(eventType, lang, limit);
+    } else {
+      events = await repo.findLatest(limit, lang);
+    }
+
+    return NextResponse.json({ data: events, count: events.length });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch geo events", code: 500 },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/markets/route.ts
+++ b/app/api/markets/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { prisma } from "../../../src/infrastructure/prisma";
+import { MarketRepository } from "../../../src/adapters/repositories/market-repository";
+import type { MarketType } from "../../../src/shared/types";
+
+const repo = new MarketRepository(prisma);
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const type = searchParams.get("type") as MarketType | null;
+
+  try {
+    if (type) {
+      const snapshots = await repo.findLatestByType(type);
+      return NextResponse.json({ data: snapshots, count: snapshots.length });
+    }
+
+    // Return all latest snapshots grouped by type
+    const types: MarketType[] = [
+      "stock_index",
+      "commodity",
+      "forex",
+      "volatility",
+      "crypto",
+    ];
+    const results: Record<string, unknown[]> = {};
+    for (const t of types) {
+      results[t] = await repo.findLatestByType(t);
+    }
+
+    return NextResponse.json({ data: results });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch markets", code: 500 },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { prisma } from "../../../src/infrastructure/prisma";
+import { NewsRepository } from "../../../src/adapters/repositories/news-repository";
+import type { Language, NewsCategory, Region } from "../../../src/shared/types";
+
+const repo = new NewsRepository(prisma);
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const lang = (searchParams.get("lang") ?? "ko") as Language;
+  const limit = Math.min(Number(searchParams.get("limit") ?? "50"), 100);
+  const region = searchParams.get("region") as Region | null;
+  const category = searchParams.get("category") as NewsCategory | null;
+
+  try {
+    let articles;
+    if (region) {
+      articles = await repo.findByRegion(region, lang, limit);
+    } else if (category) {
+      articles = await repo.findByCategory(category, lang, limit);
+    } else {
+      articles = await repo.findLatest(limit, lang);
+    }
+
+    return NextResponse.json({ data: articles, count: articles.length });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch news", code: 500 },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/vessels/route.ts
+++ b/app/api/vessels/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { prisma } from "../../../src/infrastructure/prisma";
+import { VesselRepository } from "../../../src/adapters/repositories/vessel-repository";
+import type { MaritimeZone, VesselType } from "../../../src/shared/types";
+
+const repo = new VesselRepository(prisma);
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const type = searchParams.get("type") as VesselType | null;
+  const zone = searchParams.get("zone") as MaritimeZone | null;
+
+  try {
+    if (zone) {
+      const vessels = await repo.findByZone(zone);
+      return NextResponse.json({ data: vessels, count: vessels.length });
+    }
+
+    if (type) {
+      const vessels = await repo.findByType(type);
+      return NextResponse.json({ data: vessels, count: vessels.length });
+    }
+
+    // Default: return all tanker types
+    const tankerTypes: VesselType[] = [
+      "tanker_crude",
+      "tanker_product",
+      "lpg",
+      "lng",
+    ];
+    const results = [];
+    for (const t of tankerTypes) {
+      const vessels = await repo.findByType(t);
+      results.push(...vessels);
+    }
+
+    return NextResponse.json({ data: results, count: results.length });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch vessels", code: 500 },
+      { status: 500 },
+    );
+  }
+}

--- a/src/batch/scheduler.ts
+++ b/src/batch/scheduler.ts
@@ -1,11 +1,83 @@
 import cron from "node-cron";
+import { prisma } from "../infrastructure/prisma";
+import { collectNews } from "../usecases/collect-news";
+import { collectMarket } from "../usecases/collect-market";
+import { collectGeoEvents } from "../usecases/collect-geo-events";
+import { GdeltCollector } from "../adapters/collectors/gdelt-collector";
+import { RssCollector } from "../adapters/collectors/rss-collector";
+import { GdeltGeoCollector } from "../adapters/collectors/gdelt-geo-collector";
+import { MarketCollector } from "../adapters/collectors/market-collector";
+import { NewsRepository } from "../adapters/repositories/news-repository";
+import { MarketRepository } from "../adapters/repositories/market-repository";
+import { GeoRepository } from "../adapters/repositories/geo-repository";
 
-// Batch scheduler entry point
-// Collectors will be registered here in future issues
+const newsRepo = new NewsRepository(prisma);
+const marketRepo = new MarketRepository(prisma);
+const geoRepo = new GeoRepository(prisma);
 
-console.log("Batch scheduler started");
+async function runCollectNews() {
+  const label = "collect-news";
+  console.log(`[${new Date().toISOString()}] ${label}: starting`);
+  try {
+    const gdelt = new GdeltCollector();
+    const rss = new RssCollector();
+    const result = await collectNews([gdelt, rss], newsRepo);
+    console.log(
+      `[${new Date().toISOString()}] ${label}: total=${result.total} saved=${result.saved} skipped=${result.skipped}`,
+    );
+  } catch (error) {
+    console.error(`[${new Date().toISOString()}] ${label}: error`, error);
+  }
+}
 
-// Keep process alive
-cron.schedule("*/30 * * * *", () => {
-  console.log(`[${new Date().toISOString()}] Scheduler heartbeat`);
-});
+async function runCollectMarket() {
+  const label = "collect-market";
+  console.log(`[${new Date().toISOString()}] ${label}: starting`);
+  try {
+    const collector = new MarketCollector();
+    const result = await collectMarket(collector, marketRepo);
+    console.log(
+      `[${new Date().toISOString()}] ${label}: total=${result.total} saved=${result.saved}`,
+    );
+  } catch (error) {
+    console.error(`[${new Date().toISOString()}] ${label}: error`, error);
+  }
+}
+
+async function runCollectGeoEvents() {
+  const label = "collect-geo";
+  console.log(`[${new Date().toISOString()}] ${label}: starting`);
+  try {
+    const gdeltGeo = new GdeltGeoCollector();
+    const result = await collectGeoEvents([gdeltGeo], geoRepo);
+    console.log(
+      `[${new Date().toISOString()}] ${label}: total=${result.total} saved=${result.saved} skipped=${result.skipped}`,
+    );
+  } catch (error) {
+    console.error(`[${new Date().toISOString()}] ${label}: error`, error);
+  }
+}
+
+// ─── Schedule ──────────────────────────────────────────────────
+
+// News: GDELT + RSS every 15 minutes
+cron.schedule("*/15 * * * *", runCollectNews);
+
+// Market data: Yahoo Finance every 15 minutes
+cron.schedule("*/15 * * * *", runCollectMarket);
+
+// Geopolitics: GDELT events every 30 minutes
+cron.schedule("*/30 * * * *", runCollectGeoEvents);
+
+// ─── Startup ───────────────────────────────────────────────────
+
+console.log(`[${new Date().toISOString()}] Batch scheduler started`);
+console.log("Schedules:");
+console.log("  */15 * * * *  News collection (GDELT + RSS)");
+console.log("  */15 * * * *  Market data (Yahoo Finance)");
+console.log("  */30 * * * *  Geopolitics events (GDELT)");
+
+// Run initial collection on startup
+runCollectNews();
+runCollectMarket();
+runCollectGeoEvents();


### PR DESCRIPTION
## Summary
- **배치 스케줄러**: node-cron 기반, 뉴스(15분)/시장(15분)/지정학(30분) 주기 수집, 수집기별 에러 격리
- **API Routes**: 5개 엔드포인트 (뉴스/시장/지정학/선박/브리핑), lang/region/category 필터, limit 상한 100
- M1 마일스톤의 최종 통합 — 수집기 → DB 저장 → API 서빙 파이프라인 완성

## Test plan
- [x] cron 표현식 유효성 검증 테스트
- [x] 기존 전체 테스트 통과 (131/131)
- [ ] API Routes는 Next.js 서버 필요 (수동 테스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)