### PR TITLE
feat: VesselTracking 레이아웃 + Dubai Airport Monitor

### DIFF
--- a/app/components/airport/AirlineGrid.tsx
+++ b/app/components/airport/AirlineGrid.tsx
@@ -1,0 +1,44 @@
+import type { Airline, AirlineStatusType } from "../../lib/airport-data";
+
+const STATUS_COLORS: Record<AirlineStatusType, string> = {
+  normal: "var(--accent-green)",
+  delays: "var(--accent-amber)",
+  disrupted: "var(--accent-red)",
+};
+
+interface AirlineGridProps {
+  airlines: Airline[];
+}
+
+export default function AirlineGrid({ airlines }: AirlineGridProps) {
+  return (
+    <div>
+      <div className="font-mono text-[0.58rem] tracking-[1.5px] uppercase mb-1.5" style={{ color: "var(--text-muted)" }}>
+        주요 항공사 (24H)
+      </div>
+      <div className="grid grid-cols-3 gap-1 max-lg:grid-cols-2">
+        {airlines.map((a) => (
+          <div
+            key={a.code}
+            className="flex items-center gap-2 px-2.5 py-1.5 border"
+            style={{ background: "var(--bg-secondary)", borderColor: "var(--border)" }}
+          >
+            <div
+              className="w-[5px] h-[5px] rounded-full shrink-0"
+              style={{ background: STATUS_COLORS[a.status] }}
+            />
+            <span className="font-mono text-[0.58rem] flex-1" style={{ color: "var(--text-secondary)" }}>
+              {a.name}
+            </span>
+            <span className="font-mono text-[0.65rem] font-semibold" style={{ color: "var(--text-primary)" }}>
+              {a.flights}편
+            </span>
+            <span className="font-mono text-[0.48rem]" style={{ color: STATUS_COLORS[a.status] }}>
+              {a.onTime}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/airport/AirportMapInner.tsx
+++ b/app/components/airport/AirportMapInner.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { MapContainer, TileLayer, CircleMarker, Circle, Polyline, Popup } from "react-leaflet";
+import L from "leaflet";
+import { Marker } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+import type { AirportMapData } from "../../lib/airport-data";
+
+const CONFLICT_ZONES = [
+  { center: [15.5, 44.0] as [number, number], radius: 200000, color: "#ef4444", label: "Yemen", labelPos: [14.5, 44.0] as [number, number] },
+  { center: [27.0, 52.0] as [number, number], radius: 150000, color: "#f59e0b", label: "Iran Exercise", labelPos: [28.0, 52.0] as [number, number] },
+  { center: [33.5, 44.0] as [number, number], radius: 180000, color: "#ef4444", label: "Iraq/Syria", labelPos: [34.5, 44.0] as [number, number] },
+  { center: [26.5, 56.3] as [number, number], radius: 50000, color: "#f59e0b", label: "Hormuz", labelPos: [26.0, 57.0] as [number, number] },
+];
+
+function aircraftIcon(cls: string, rotation: number) {
+  const color = cls === "ek" ? "#f59e0b" : cls === "conflict-zone" ? "#ef4444" : "#94a3b8";
+  return L.divIcon({
+    className: "",
+    html: `<div style="font-size:12px;color:${color};transform:rotate(${rotation}deg);filter:drop-shadow(0 0 4px ${color}80);line-height:1">✈</div>`,
+    iconSize: [14, 14],
+    iconAnchor: [7, 7],
+  });
+}
+
+function labelIcon(text: string, color: string) {
+  return L.divIcon({
+    className: "",
+    html: `<div style="font-family:monospace;font-size:9px;color:${color};text-shadow:0 0 6px ${color}80;white-space:nowrap">${text}</div>`,
+    iconSize: [80, 14],
+    iconAnchor: [40, 7],
+  });
+}
+
+interface AirportMapInnerProps {
+  mapData: AirportMapData;
+}
+
+export default function AirportMapInner({ mapData }: AirportMapInnerProps) {
+  const dxbIcon = L.divIcon({
+    className: "",
+    html: `<div style="font-family:monospace;font-size:11px;font-weight:bold;color:#f59e0b;text-shadow:0 0 10px rgba(245,158,11,0.8)">DXB</div>`,
+    iconSize: [30, 14],
+    iconAnchor: [15, 7],
+  });
+
+  return (
+    <MapContainer
+      center={[25.25, 55.36]}
+      zoom={6}
+      style={{ height: "100%", width: "100%", background: "#0a0e17" }}
+      zoomControl={false}
+      attributionControl={false}
+    >
+      <TileLayer url="https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png" />
+      <TileLayer url="https://{s}.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}{r}.png" opacity={0.4} />
+
+      {/* DXB marker */}
+      <Marker position={[25.253, 55.365]} icon={dxbIcon} interactive={false} />
+
+      {/* Approach zones */}
+      <Circle
+        center={[25.253, 55.365]}
+        radius={60000}
+        pathOptions={{ color: "#f59e0b", fillOpacity: 0, weight: 1, dashArray: "4 4" }}
+      />
+      <Circle
+        center={[25.253, 55.365]}
+        radius={150000}
+        pathOptions={{ color: "#06b6d4", fillOpacity: 0, weight: 1, dashArray: "6 6", opacity: 0.4 }}
+      />
+
+      {/* Conflict zones */}
+      {CONFLICT_ZONES.map((zone) => (
+        <Circle
+          key={zone.label}
+          center={zone.center}
+          radius={zone.radius}
+          pathOptions={{
+            color: zone.color,
+            fillColor: zone.color,
+            fillOpacity: 0.08,
+            weight: 1,
+            dashArray: "4 4",
+          }}
+        />
+      ))}
+      {CONFLICT_ZONES.map((zone) => (
+        <Marker key={`label-${zone.label}`} position={zone.labelPos} icon={labelIcon(zone.label, zone.color)} interactive={false} />
+      ))}
+
+      {/* Flight paths */}
+      {mapData.flightPaths.map((fp, i) => (
+        <Polyline
+          key={i}
+          positions={[[25.253, 55.365], fp.dest]}
+          pathOptions={{
+            color: fp.color,
+            weight: 1,
+            opacity: 0.2,
+            dashArray: fp.dashArray ?? "6 6",
+          }}
+        />
+      ))}
+
+      {/* Aircraft markers */}
+      {mapData.aircraft.map((ac) => (
+        <Marker key={ac.flightLabel} position={[ac.lat, ac.lng]} icon={aircraftIcon(ac.cls, ac.rotation)}>
+          <Popup>
+            <div style={{ fontFamily: "monospace", fontSize: "0.7rem" }}>
+              <div style={{ fontWeight: "bold", color: ac.cls === "ek" ? "#f59e0b" : "#94a3b8", marginBottom: 2 }}>
+                {ac.flightLabel}
+              </div>
+              <div style={{ fontSize: "0.6rem", color: "#94a3b8" }}>{ac.altLabel}</div>
+            </div>
+          </Popup>
+        </Marker>
+      ))}
+    </MapContainer>
+  );
+}

--- a/app/components/airport/AirportMonitor.tsx
+++ b/app/components/airport/AirportMonitor.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import {
+  AIRPORT_STATUS,
+  TIMELINE_EVENTS,
+  AIRLINES,
+  EK_ROUTES,
+  AIRPORT_MAP_DATA,
+} from "../../lib/airport-data";
+import AirportTimeline from "./AirportTimeline";
+import AirlineGrid from "./AirlineGrid";
+import EKRouteBadges from "./EKRouteBadges";
+
+const AirportMapInner = dynamic(() => import("./AirportMapInner"), { ssr: false });
+
+const STATUS_LIGHT_COLORS: Record<string, string> = {
+  green: "var(--accent-green)",
+  amber: "var(--accent-amber)",
+  red: "var(--accent-red)",
+};
+
+export default function AirportMonitor() {
+  return (
+    <div className="p-5 flex flex-col gap-3" style={{ background: "var(--bg-primary)" }}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div
+            className="w-2 h-2"
+            style={{ background: "var(--accent-amber)", clipPath: "polygon(50% 0%,100% 50%,50% 100%,0% 50%)" }}
+          />
+          <h2 className="font-mono text-[0.72rem] font-semibold tracking-[2px] uppercase" style={{ color: "var(--text-secondary)" }}>
+            DUBAI INTL (DXB) — 항공 모니터
+          </h2>
+        </div>
+        <span className="font-mono text-[0.55rem] tracking-[1px]" style={{ color: "var(--text-muted)" }}>
+          1H CYCLE · LAST 7D
+        </span>
+      </div>
+
+      {/* Status bar */}
+      <div
+        className="flex items-center gap-3 px-3 py-2 border"
+        style={{ background: "var(--bg-secondary)", borderColor: "var(--border)" }}
+      >
+        <div
+          className="w-2 h-2 rounded-full"
+          style={{
+            background: STATUS_LIGHT_COLORS[AIRPORT_STATUS.light],
+            boxShadow: `0 0 8px ${STATUS_LIGHT_COLORS[AIRPORT_STATUS.light]}`,
+            animation: "pulse-dot 2s ease-in-out infinite",
+          }}
+        />
+        <span className="font-mono text-[0.65rem] font-semibold tracking-[1px]" style={{ color: STATUS_LIGHT_COLORS[AIRPORT_STATUS.light] }}>
+          {AIRPORT_STATUS.label}
+        </span>
+        <span className="font-mono text-[0.58rem]" style={{ color: "var(--text-muted)" }}>
+          {AIRPORT_STATUS.runways}
+        </span>
+        <span className="font-mono text-[0.6rem] ml-auto" style={{ color: "var(--text-muted)" }}>
+          {AIRPORT_STATUS.weather}
+        </span>
+      </div>
+
+      {/* Map + Timeline side by side */}
+      <div className="grid grid-cols-2 gap-px max-lg:grid-cols-1" style={{ background: "var(--border)" }}>
+        {/* Map with radar */}
+        <div className="relative" style={{ background: "var(--bg-primary)" }}>
+          <div className="border overflow-hidden" style={{ borderColor: "var(--border)", height: 420 }}>
+            <AirportMapInner mapData={AIRPORT_MAP_DATA} />
+          </div>
+          {/* Radar sweep overlay */}
+          <div
+            className="absolute inset-0 pointer-events-none"
+            style={{
+              zIndex: 500,
+              background: "conic-gradient(from 0deg at 60% 45%, rgba(6,182,212,0.08) 0deg, transparent 60deg, transparent 360deg)",
+              animation: "radar-rotate 4s linear infinite",
+            }}
+          />
+          {/* Flight counter */}
+          <div
+            className="absolute top-2 left-2 z-[600] px-2 py-1 font-mono text-[0.6rem] border"
+            style={{ background: "rgba(10,14,23,0.85)", borderColor: "var(--border)" }}
+          >
+            <span style={{ color: "var(--accent-cyan)" }}>✈ {AIRPORT_MAP_DATA.aircraft.length}</span>
+            <span className="mx-1" style={{ color: "var(--text-muted)" }}>TRACKED</span>
+            <span style={{ color: "var(--accent-amber)" }}>EK {AIRPORT_MAP_DATA.aircraft.filter((a) => a.cls === "ek").length}</span>
+            <span className="ml-1" style={{ color: "var(--text-muted)" }}>
+              OTHER {AIRPORT_MAP_DATA.aircraft.filter((a) => a.cls !== "ek").length}
+            </span>
+          </div>
+          {/* Legend */}
+          <div
+            className="absolute bottom-2 right-2 z-[600] px-2 py-1 font-mono text-[0.55rem] border"
+            style={{ background: "rgba(10,14,23,0.85)", borderColor: "var(--border)" }}
+          >
+            <span style={{ color: "var(--accent-red)" }}>◉ 분쟁구역</span>
+            <span className="ml-1.5" style={{ color: "var(--accent-amber)" }}>◉ 경계구역</span>
+            <span className="ml-1.5" style={{ color: "var(--accent-green)" }}>◉ 안전</span>
+          </div>
+        </div>
+
+        {/* Timeline */}
+        <div className="pt-3 pr-2.5" style={{ background: "var(--bg-primary)" }}>
+          <AirportTimeline events={TIMELINE_EVENTS} />
+        </div>
+      </div>
+
+      {/* Bottom row: Airlines + Routes */}
+      <div className="grid grid-cols-2 gap-3 max-lg:grid-cols-1">
+        <AirlineGrid airlines={AIRLINES} />
+        <EKRouteBadges routes={EK_ROUTES} />
+      </div>
+    </div>
+  );
+}

--- a/app/components/airport/AirportTimeline.tsx
+++ b/app/components/airport/AirportTimeline.tsx
@@ -1,0 +1,103 @@
+import type { TimelineEvent, TimelineEventType } from "../../lib/airport-data";
+
+const DOT_STYLES: Record<TimelineEventType, string> = {
+  conflict: "#ef4444",
+  ops: "#f59e0b",
+  normal: "#22c55e",
+  info: "#06b6d4",
+};
+
+const TAG_STYLES: Record<TimelineEventType, { color: string; bg: string }> = {
+  conflict: { color: "var(--accent-red)", bg: "var(--accent-red-dim)" },
+  ops: { color: "var(--accent-amber)", bg: "var(--accent-amber-dim)" },
+  normal: { color: "var(--accent-green)", bg: "var(--accent-green-dim)" },
+  info: { color: "var(--accent-cyan)", bg: "var(--accent-cyan-dim)" },
+};
+
+interface AirportTimelineProps {
+  events: TimelineEvent[];
+}
+
+export default function AirportTimeline({ events }: AirportTimelineProps) {
+  return (
+    <div>
+      <div
+        className="font-mono text-[0.58rem] tracking-[1.5px] uppercase mb-2"
+        style={{ color: "var(--text-muted)", paddingLeft: 10 }}
+      >
+        7일 타임라인
+      </div>
+      <div
+        className="overflow-y-auto py-1"
+        style={{ maxHeight: 420, scrollbarWidth: "thin", scrollbarColor: "var(--border-active) transparent" }}
+      >
+        {events.map((event, i) => (
+          <div
+            key={event.date}
+            className="grid items-start relative"
+            style={{ gridTemplateColumns: "52px 20px 1fr", minHeight: 52 }}
+          >
+            {/* Date */}
+            <div
+              className="text-right pr-2 pt-1.5 font-mono text-[0.58rem] leading-tight"
+              style={{ color: event.isToday ? "var(--accent-cyan)" : "var(--text-muted)" }}
+            >
+              {event.date}
+              <span
+                className="block text-[0.48rem]"
+                style={{ opacity: event.isToday ? 0.8 : 0.6 }}
+              >
+                {event.dayLabel}
+              </span>
+            </div>
+
+            {/* Stem + Dot */}
+            <div className="flex flex-col items-center relative">
+              {/* Vertical line */}
+              <div
+                className="absolute top-0 bottom-0 w-px"
+                style={{ background: "var(--border)", left: "50%", transform: "translateX(-50%)" }}
+              />
+              {/* Dot */}
+              <div
+                className="w-2 h-2 rounded-full mt-2 relative z-10 shrink-0"
+                style={{
+                  background: DOT_STYLES[event.dotType],
+                  boxShadow: `0 0 6px ${DOT_STYLES[event.dotType]}80`,
+                }}
+              />
+            </div>
+
+            {/* Card */}
+            <div
+              className="my-1 ml-1.5 px-2.5 py-1.5 text-[0.6rem] leading-[1.45] border"
+              style={{
+                background: event.isToday ? "rgba(6,182,212,0.04)" : "var(--bg-secondary)",
+                borderColor: event.isToday ? "rgba(6,182,212,0.25)" : "var(--border)",
+                color: "var(--text-secondary)",
+              }}
+            >
+              {event.entries.map((entry, j) => (
+                <div key={j} className={j > 0 ? "mt-1" : ""}>
+                  {entry.tags.map((tag, k) => {
+                    const s = TAG_STYLES[tag.type];
+                    return (
+                      <span
+                        key={k}
+                        className="font-mono text-[0.46rem] font-semibold tracking-[0.5px] inline-block mr-1 align-middle"
+                        style={{ color: s.color, background: s.bg, padding: "1px 4px" }}
+                      >
+                        {tag.label}
+                      </span>
+                    );
+                  })}
+                  {entry.text}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/airport/EKRouteBadges.tsx
+++ b/app/components/airport/EKRouteBadges.tsx
@@ -1,0 +1,42 @@
+import type { EKRoute, RouteStatus } from "../../lib/airport-data";
+
+const STATUS_STYLES: Record<RouteStatus, { color: string; bg: string; label: string }> = {
+  open: { color: "var(--accent-green)", bg: "var(--accent-green-dim)", label: "OPEN" },
+  diverted: { color: "var(--accent-amber)", bg: "var(--accent-amber-dim)", label: "DIVRT" },
+  suspended: { color: "var(--accent-red)", bg: "var(--accent-red-dim)", label: "SUSP" },
+};
+
+interface EKRouteBadgesProps {
+  routes: EKRoute[];
+}
+
+export default function EKRouteBadges({ routes }: EKRouteBadgesProps) {
+  return (
+    <div>
+      <div className="font-mono text-[0.58rem] tracking-[1.5px] uppercase mb-1.5" style={{ color: "var(--accent-amber)" }}>
+        EK 노선 현황
+      </div>
+      <div className="grid grid-cols-3 gap-1 max-lg:grid-cols-2">
+        {routes.map((r) => {
+          const s = STATUS_STYLES[r.status];
+          return (
+            <div
+              key={r.flightCode}
+              className="flex items-center gap-1 px-2.5 py-1.5 font-mono text-[0.52rem] border"
+              style={{ background: "var(--bg-secondary)", borderColor: "var(--border)" }}
+            >
+              <span style={{ color: "var(--text-secondary)", letterSpacing: "0.3px" }}>{r.dest}</span>
+              <span style={{ color: "var(--text-muted)", fontSize: "0.48rem" }}>{r.flightCode}</span>
+              <span
+                className="ml-auto font-semibold"
+                style={{ color: s.color, background: s.bg, padding: "0 3px", fontSize: "0.46rem", letterSpacing: "0.3px" }}
+              >
+                {s.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/components/vessels/VesselTracking.tsx
+++ b/app/components/vessels/VesselTracking.tsx
@@ -47,54 +47,44 @@ export default function VesselTracking() {
   const anomalies = getAnomalies(allVessels);
 
   return (
-    <section
-      className="grid grid-cols-[1fr_340px] gap-px max-lg:grid-cols-1"
-      style={{
-        background: "var(--border)",
-        animation: "fade-in-up 0.4s ease-out 0.2s both",
-      }}
-    >
-      {/* Map panel */}
-      <div className="p-5" style={{ background: "var(--bg-primary)" }}>
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <div
-              className="w-2 h-2"
-              style={{ background: "var(--accent-cyan)", clipPath: "polygon(50% 0%,100% 50%,50% 100%,0% 50%)" }}
-            />
-            <h2 className="font-mono text-[0.72rem] font-semibold tracking-[2px] uppercase" style={{ color: "var(--text-secondary)" }}>
-              중동 해역 선박 추적
-            </h2>
-          </div>
-        </div>
-
-        <div
-          className="relative w-full border overflow-hidden"
-          style={{ borderColor: "var(--border)", height: 340 }}
-        >
-          {isLoading ? (
-            <div
-              className="flex items-center justify-center h-full"
-              style={{ background: "#0a0e17" }}
-            >
-              <span className="font-mono text-[0.6rem] tracking-[2px]" style={{ color: "var(--text-muted)", opacity: 0.4 }}>
-                LOADING MAP...
-              </span>
-            </div>
-          ) : (
-            <VesselMapInner vessels={allVessels} />
-          )}
+    <div className="p-5 flex flex-col gap-3" style={{ background: "var(--bg-primary)" }}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div
+            className="w-2 h-2"
+            style={{ background: "var(--accent-cyan)", clipPath: "polygon(50% 0%,100% 50%,50% 100%,0% 50%)" }}
+          />
+          <h2 className="font-mono text-[0.72rem] font-semibold tracking-[2px] uppercase" style={{ color: "var(--text-secondary)" }}>
+            중동 해역 선박 추적
+          </h2>
         </div>
       </div>
 
-      {/* Info panel */}
-      <div className="p-5 flex flex-col gap-4" style={{ background: "var(--bg-primary)" }}>
+      {/* Map */}
+      <div
+        className="relative w-full border overflow-hidden"
+        style={{ borderColor: "var(--border)", height: 340 }}
+      >
+        {isLoading ? (
+          <div className="flex items-center justify-center h-full" style={{ background: "#0a0e17" }}>
+            <span className="font-mono text-[0.6rem] tracking-[2px]" style={{ color: "var(--text-muted)", opacity: 0.4 }}>
+              LOADING MAP...
+            </span>
+          </div>
+        ) : (
+          <VesselMapInner vessels={allVessels} />
+        )}
+      </div>
+
+      {/* Passage Stats (left) + Anomaly Alerts (right) */}
+      <div className="grid grid-cols-2 gap-2 max-lg:grid-cols-1">
         {/* Passage stats */}
         <div>
-          <h3 className="font-mono text-[0.65rem] tracking-[1.5px] uppercase mb-2" style={{ color: "var(--text-muted)" }}>
+          <h3 className="font-mono text-[0.55rem] tracking-[1.5px] uppercase mb-1" style={{ color: "var(--text-muted)" }}>
             해협별 통과 현황 (24H)
           </h3>
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-1">
             {isLoading ? (
               <span className="font-mono text-[0.68rem]" style={{ color: "var(--text-muted)" }}>LOADING...</span>
             ) : zoneStats.length === 0 ? (
@@ -103,22 +93,22 @@ export default function VesselTracking() {
               zoneStats.slice(0, 3).map((z) => (
                 <div
                   key={z.zone}
-                  className="flex items-center justify-between px-3 py-2.5 border"
+                  className="flex items-center justify-between px-2 py-1.5 border"
                   style={{ background: "var(--bg-secondary)", borderColor: "var(--border)" }}
                 >
                   <div>
-                    <div className="font-mono text-[0.68rem] tracking-[0.5px]" style={{ color: "var(--text-secondary)" }}>
+                    <div className="font-mono text-[0.58rem] tracking-[0.5px]" style={{ color: "var(--text-secondary)" }}>
                       {z.ko}
                     </div>
-                    <div className="font-mono text-[0.55rem]" style={{ color: "var(--text-muted)" }}>
+                    <div className="font-mono text-[0.46rem]" style={{ color: "var(--text-muted)" }}>
                       {z.en}
                     </div>
                   </div>
-                  <div className="flex items-center gap-3">
-                    <span className="font-mono text-[1.1rem] font-bold" style={{ color: "var(--text-primary)" }}>
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-[0.8rem] font-bold" style={{ color: "var(--text-primary)" }}>
                       {z.count}
                     </span>
-                    <span className="font-mono text-[0.55rem]" style={{ color: "var(--text-muted)" }}>
+                    <span className="font-mono text-[0.46rem]" style={{ color: "var(--text-muted)" }}>
                       척
                     </span>
                   </div>
@@ -130,7 +120,7 @@ export default function VesselTracking() {
 
         {/* Anomaly alerts */}
         <div>
-          <h3 className="font-mono text-[0.65rem] tracking-[1.5px] uppercase mb-2" style={{ color: "var(--accent-amber)" }}>
+          <h3 className="font-mono text-[0.55rem] tracking-[1.5px] uppercase mb-1" style={{ color: "var(--accent-amber)" }}>
             이상 감지 알림
           </h3>
           <div className="flex flex-col gap-1">
@@ -139,12 +129,12 @@ export default function VesselTracking() {
                 이상 감지 없음
               </span>
             ) : (
-              anomalies.slice(0, 5).map((v) => {
+              anomalies.slice(0, 3).map((v) => {
                 const isCritical = v.latestPosition?.status === "anomaly";
                 return (
                   <div
                     key={v.id}
-                    className="flex items-start gap-2 px-2.5 py-2 border text-[0.72rem]"
+                    className="flex items-start gap-2 px-2 py-1.5 border text-[0.68rem]"
                     style={{
                       background: isCritical ? "var(--accent-red-dim)" : "var(--accent-amber-dim)",
                       borderColor: isCritical ? "rgba(239,68,68,0.15)" : "rgba(245,158,11,0.15)",
@@ -152,19 +142,19 @@ export default function VesselTracking() {
                     }}
                   >
                     <span
-                      className="font-mono text-[0.6rem] font-bold shrink-0 mt-px"
+                      className="font-mono text-[0.55rem] font-bold shrink-0 mt-px"
                       style={{ color: isCritical ? "var(--accent-red)" : "var(--accent-amber)" }}
                     >
                       {isCritical ? "!!" : "!"}
                     </span>
                     <div>
                       <div
-                        className="text-[0.68rem] font-medium mb-0.5"
+                        className="text-[0.6rem] font-medium mb-0.5"
                         style={{ color: isCritical ? "var(--accent-red)" : "var(--accent-amber)" }}
                       >
                         {v.name} — {v.latestPosition?.status.toUpperCase()}
                       </div>
-                      <div className="text-[0.6rem]" style={{ color: "var(--text-muted)" }}>
+                      <div className="text-[0.55rem]" style={{ color: "var(--text-muted)" }}>
                         {v.type} · {v.latestPosition?.speed ?? 0} kn · {v.latestPosition?.zone ?? "—"}
                       </div>
                     </div>
@@ -175,6 +165,6 @@ export default function VesselTracking() {
           </div>
         </div>
       </div>
-    </section>
+    </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -142,6 +142,15 @@ body::after {
   }
 }
 
+@keyframes radar-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Card hover styles */
 .news-item-card {
   background: var(--bg-secondary);

--- a/app/lib/airport-data.ts
+++ b/app/lib/airport-data.ts
@@ -1,0 +1,183 @@
+export interface AirportStatus {
+  light: "green" | "amber" | "red";
+  label: string;
+  runways: string;
+  weather: string;
+}
+
+export type TimelineEventType = "conflict" | "ops" | "normal" | "info";
+
+export interface TimelineTag {
+  type: TimelineEventType;
+  label: string;
+}
+
+export interface TimelineEvent {
+  date: string;
+  dayLabel: string;
+  isToday: boolean;
+  dotType: TimelineEventType;
+  entries: { tags: TimelineTag[]; text: string }[];
+}
+
+export type AirlineStatusType = "normal" | "delays" | "disrupted";
+
+export interface Airline {
+  code: string;
+  name: string;
+  flights: number;
+  onTime: number;
+  status: AirlineStatusType;
+}
+
+export type RouteStatus = "open" | "diverted" | "suspended";
+
+export interface EKRoute {
+  dest: string;
+  flightCode: string;
+  status: RouteStatus;
+}
+
+export interface Aircraft {
+  lat: number;
+  lng: number;
+  rotation: number;
+  flightLabel: string;
+  altLabel: string;
+  cls: "ek" | "other" | "conflict-zone";
+}
+
+export interface FlightPath {
+  dest: [number, number];
+  color: string;
+  dashArray?: string;
+}
+
+export interface AirportMapData {
+  aircraft: Aircraft[];
+  flightPaths: FlightPath[];
+}
+
+export const AIRPORT_STATUS: AirportStatus = {
+  light: "green",
+  label: "OPERATIONAL",
+  runways: "RWY 12L/30R · 12R/30L ACTIVE",
+  weather: "VIS 10km+ · WIND 320°/12kt",
+};
+
+export const TIMELINE_EVENTS: TimelineEvent[] = [
+  {
+    date: "3/14",
+    dayLabel: "TODAY",
+    isToday: true,
+    dotType: "normal",
+    entries: [
+      { tags: [{ type: "normal", label: "OPS" }], text: "DXB 전 활주로 정상운영" },
+      { tags: [{ type: "conflict", label: "WATCH" }], text: "이란 훈련 지속 · 항로 감시중" },
+    ],
+  },
+  {
+    date: "3/13",
+    dayLabel: "THU",
+    isToday: false,
+    dotType: "info",
+    entries: [{ tags: [{ type: "info", label: "INTEL" }], text: "UAE 방공체계 경계 격상" }],
+  },
+  {
+    date: "3/12",
+    dayLabel: "WED",
+    isToday: false,
+    dotType: "ops",
+    entries: [
+      { tags: [{ type: "ops", label: "DELAY" }], text: "IKA행 평균 1.5H 지연" },
+      { tags: [{ type: "normal", label: "SAFE" }], text: "DXB 동측 항로 정상화" },
+    ],
+  },
+  {
+    date: "3/11",
+    dayLabel: "TUE",
+    isToday: false,
+    dotType: "conflict",
+    entries: [{ tags: [{ type: "conflict", label: "STRIKE" }], text: "이란 IRGC 걸프만 미사일 시험" }],
+  },
+  {
+    date: "3/10",
+    dayLabel: "MON",
+    isToday: false,
+    dotType: "ops",
+    entries: [
+      { tags: [{ type: "ops", label: "REROUTE" }], text: "DXB-유럽 노선 남측 우회" },
+      { tags: [{ type: "info", label: "EK" }], text: "TLV/BEY 노선 중단 발표" },
+    ],
+  },
+  {
+    date: "3/9",
+    dayLabel: "SUN",
+    isToday: false,
+    dotType: "conflict",
+    entries: [{ tags: [{ type: "conflict", label: "ALERT" }], text: "이란 해군 호르무즈 훈련 개시" }],
+  },
+  {
+    date: "3/8",
+    dayLabel: "SAT",
+    isToday: false,
+    dotType: "conflict",
+    entries: [
+      { tags: [{ type: "conflict", label: "STRIKE" }], text: "예멘 후티, 홍해 드론 공격" },
+      { tags: [{ type: "ops", label: "NOTAM" }], text: "DXB 남측 항로 제한" },
+    ],
+  },
+];
+
+export const AIRLINES: Airline[] = [
+  { code: "EK", name: "에미레이트 (EK)", flights: 142, onTime: 98, status: "normal" },
+  { code: "FZ", name: "플라이두바이 (FZ)", flights: 86, onTime: 95, status: "normal" },
+  { code: "QR", name: "카타르항공 (QR)", flights: 38, onTime: 82, status: "delays" },
+  { code: "KE", name: "대한항공 (KE)", flights: 4, onTime: 100, status: "normal" },
+  { code: "LH", name: "루프트한자 (LH)", flights: 6, onTime: 78, status: "delays" },
+  { code: "IR", name: "이란항공 (IR)", flights: 2, onTime: 50, status: "disrupted" },
+];
+
+export const EK_ROUTES: EKRoute[] = [
+  { dest: "ICN", flightCode: "EK322", status: "open" },
+  { dest: "LHR", flightCode: "EK001", status: "open" },
+  { dest: "NRT", flightCode: "EK318", status: "open" },
+  { dest: "SIN", flightCode: "EK354", status: "open" },
+  { dest: "JFK", flightCode: "EK201", status: "open" },
+  { dest: "CDG", flightCode: "EK073", status: "open" },
+  { dest: "IKA", flightCode: "EK971", status: "diverted" },
+  { dest: "TLV", flightCode: "EK931", status: "suspended" },
+  { dest: "BEY", flightCode: "EK957", status: "suspended" },
+  { dest: "DME", flightCode: "EK131", status: "open" },
+  { dest: "BKK", flightCode: "EK384", status: "open" },
+  { dest: "SYD", flightCode: "EK414", status: "open" },
+];
+
+export const AIRPORT_MAP_DATA: AirportMapData = {
+  aircraft: [
+    { lat: 26.1, lng: 54.8, rotation: 210, flightLabel: "EK302 ICN", altLabel: "FL380", cls: "ek" },
+    { lat: 24.8, lng: 56.2, rotation: 45, flightLabel: "EK412 SYD", altLabel: "FL350", cls: "ek" },
+    { lat: 25.8, lng: 53.5, rotation: 90, flightLabel: "EK001 LHR", altLabel: "FL400", cls: "ek" },
+    { lat: 24.2, lng: 55.8, rotation: 340, flightLabel: "EK201 JFK", altLabel: "FL390", cls: "ek" },
+    { lat: 25.5, lng: 55.1, rotation: 180, flightLabel: "EK318 NRT", altLabel: "FL360", cls: "ek" },
+    { lat: 26.5, lng: 56.5, rotation: 270, flightLabel: "EK073 CDG", altLabel: "FL370", cls: "ek" },
+    { lat: 25.0, lng: 54.0, rotation: 120, flightLabel: "EK384 BKK", altLabel: "FL340", cls: "ek" },
+    { lat: 25.9, lng: 55.8, rotation: 60, flightLabel: "EK131 DME", altLabel: "FL380", cls: "ek" },
+    { lat: 23.8, lng: 54.5, rotation: 15, flightLabel: "QR102", altLabel: "FL350", cls: "other" },
+    { lat: 26.8, lng: 54.2, rotation: 200, flightLabel: "LH630", altLabel: "FL370", cls: "other" },
+    { lat: 25.1, lng: 57.0, rotation: 280, flightLabel: "KE952", altLabel: "FL380", cls: "other" },
+    { lat: 24.5, lng: 53.8, rotation: 90, flightLabel: "FZ201", altLabel: "FL280", cls: "other" },
+    { lat: 27.2, lng: 55.5, rotation: 170, flightLabel: "FZ445", altLabel: "FL320", cls: "other" },
+    { lat: 24.0, lng: 56.5, rotation: 350, flightLabel: "9W540", altLabel: "FL340", cls: "other" },
+    { lat: 26.3, lng: 53.0, rotation: 110, flightLabel: "FZ877", altLabel: "FL300", cls: "other" },
+    { lat: 25.7, lng: 56.8, rotation: 230, flightLabel: "SQ492", altLabel: "FL390", cls: "other" },
+  ],
+  flightPaths: [
+    { dest: [37.5, 127.0], color: "#f59e0b" },
+    { dest: [51.47, -0.46], color: "#f59e0b" },
+    { dest: [35.76, 140.39], color: "#f59e0b" },
+    { dest: [40.64, -73.78], color: "#f59e0b", dashArray: "8 4" },
+    { dest: [49.0, 2.55], color: "#f59e0b" },
+    { dest: [13.68, 100.75], color: "#f59e0b" },
+  ],
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import WorldMap from "./components/map/WorldMap";
 import NewsFeed from "./components/news/NewsFeed";
 import IssueTracker from "./components/issues/IssueTracker";
 import VesselTracking from "./components/vessels/VesselTracking";
+import AirportMonitor from "./components/airport/AirportMonitor";
 import MarketSection from "./components/markets/MarketSection";
 import AiAnalysis from "./components/analysis/AiAnalysis";
 
@@ -49,7 +50,11 @@ export default function DashboardPage() {
 
       {/* Full-width sections */}
       <div className="flex flex-col gap-px" style={{ background: "var(--border)" }}>
-        <VesselTracking />
+        {/* Vessel + Airport tracking row */}
+        <div className="grid grid-cols-2 gap-px max-lg:grid-cols-1" style={{ background: "var(--border)" }}>
+          <VesselTracking />
+          <AirportMonitor />
+        </div>
         <MarketSection />
         <AiAnalysis />
       </div>


### PR DESCRIPTION
## Summary
- VesselTracking 레이아웃 변경: 지도 전체폭 + 하단 2열(해협별 통과현황 / 이상감지 알림)
- Dubai Airport Monitor 신규 컴포넌트: Leaflet 지도(레이더 스윕, 분쟁구역, 항공기), 수직 타임라인(최신순 7일), 항공사 현황(3열), EK 노선 뱃지(3열)
- page.tsx에서 Vessel + Airport 50/50 tracking row로 배치

## Test plan
- [ ] `npx tsc --noEmit` 타입 체크 통과
- [ ] `npm run dev` → 선박 추적 레이아웃 변경 확인 (지도 + 하단 2열)
- [ ] Dubai Airport 섹션 표시 확인 (지도, 타임라인, 항공사, 노선)
- [ ] 반응형 확인 (max-lg 시 1열 스택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)